### PR TITLE
Add support for Nextcloud 28 and PHP 8.3

### DIFF
--- a/.github/workflows/static-analysis.yml
+++ b/.github/workflows/static-analysis.yml
@@ -13,17 +13,26 @@ jobs:
           - 'dev-stable25'
           - 'dev-stable26'
           - 'dev-stable27'
+          - 'dev-stable28'
           - 'dev-master'
         php:
           - '8.0'
           - '8.1'
+          - '8.2'
+          - '8.3'
         include:
-          - ocp: 'dev-stable27'
-            php: '8.2'
+          - ocp: 'dev-stable24'
+            php: '8.0'
+          - ocp: 'dev-stable25'
+            php: '8.1'
           - ocp: 'dev-stable26'
             php: '8.2'
-          - ocp: 'dev-master'
+          - ocp: 'dev-stable27'
             php: '8.2'
+          - ocp: 'dev-stable28'
+            php: '8.3'
+          - ocp: 'dev-master'
+            php: '8.3'
     name: Nextcloud ${{ matrix.ocp }} on PHP ${{ matrix.php }}
     steps:
       - name: Checkout

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,13 @@
 # Changelog
 Notable changes in [changelog format](https://keepachangelog.com/en/1.0.0/), project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html)
 
+## 2.7.4 (2023-11-06)
+
+### Added
+
+- Support for Nextcloud 28 (tested against beta1)
+- Support for PHP 8.3
+
 ## 2.7.3 (2023-05-20)
 
 ### Added

--- a/appinfo/info.xml
+++ b/appinfo/info.xml
@@ -1,10 +1,10 @@
 <?xml version="1.0"?>
 <info xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:noNamespaceSchemaLocation="https://apps.nextcloud.com/schema/apps/info.xsd">
 	<id>twofactor_email</id>
-	<version>2.7.3</version>
+	<version>2.7.4</version>
 	<dependencies>
-		<nextcloud min-version="24" max-version="27" />
-		<php min-version="8.0" max-version="8.2" />
+		<nextcloud min-version="24" max-version="28" />
+		<php min-version="8.0" max-version="8.3" />
 	</dependencies>
 	<repository type="git">https://github.com/nursoda/twofactor_email.git</repository>
 	<licence>agpl</licence>


### PR DESCRIPTION
Leave NC 24 and 25 since they run with the icurrent minimum PHP version 8.0. Allow for NC 28 (tested against NC28 beta 1 only!) and PHP 8.3 (untested).