### PR TITLE
Nextcloud 31 compatibility

### DIFF
--- a/appinfo/info.xml
+++ b/appinfo/info.xml
@@ -3,8 +3,8 @@
 	<id>twofactor_email</id>
 	<version>2.7.4</version>
 	<dependencies>
-		<nextcloud min-version="24" max-version="29" />
-		<php min-version="8.0" max-version="8.3" />
+		<nextcloud min-version="24" max-version="31" />
+		<php min-version="8.0" max-version="8.4" />
 	</dependencies>
 	<repository type="git">https://github.com/nursoda/twofactor_email.git</repository>
 	<licence>agpl</licence>

--- a/lib/Service/Email.php
+++ b/lib/Service/Email.php
@@ -6,7 +6,7 @@ namespace OCA\TwoFactorEmail\Service;
 
 use OCP\Defaults;
 use OCP\IL10N;
-use OCP\ILogger;
+use Psr\Log\LoggerInterface;
 use OCP\IUser;
 use OCP\Mail\IMailer;
 
@@ -17,7 +17,7 @@ class Email {
 	/** @var IL10N */
 	private $l10n;
 
-	/** @var ILogger */
+	/** @var LoggerInterface */
 	private $logger;
 
 	/** @var Defaults */
@@ -25,7 +25,7 @@ class Email {
 
 	public function __construct(IMailer $mailer,
 								IL10N $l10n,
-								ILogger $logger,
+								LoggerInterface $logger,
 								Defaults $themingDefaults) {
 		$this->mailer = $mailer;
 		$this->l10n = $l10n;


### PR DESCRIPTION
# Description
Nextcloud 31 compatibility Nextcloud 31 do not run without this fix.

## Related Issues
https://github.com/nursoda/twofactor_email/issues/383
https://github.com/datenschutz-individuell/twofactor_email/issues/3

## Contributor's checklist
- [x ] Description states the purpose of the modifications
- [x] The PR contains only relevant modifications
- [x] Issues are linked (if applicable)
- [ ] PHP-Code adheres to [PSR-12](https://www.php-fig.org/psr/psr-12/)
- [ ] JS-Code adheres to [standardJS](https://standardjs.com/index.html)
- [ ] Commits are atomic with a clear description
- [ ] Changelog contains a user-centric summary
- [x] All modifications are tested (think of edge cases)
- [ ] GitHub actions succeed
