### PR TITLE
Use new default branches for CodeQL analysis

### DIFF
--- a/.github/workflows/codeql-analysis.yml
+++ b/.github/workflows/codeql-analysis.yml
@@ -13,10 +13,10 @@ name: "CodeQL"
 
 on:
   push:
-    branches: [ main ]
+    branches: [ v2, v3 ]
   pull_request:
     # The branches below must be a subset of the branches above
-    branches: [ main ]
+    branches: [ v2, v3 ]
   schedule:
     - cron: '28 16 * * 2'
 


### PR DESCRIPTION
# Description
There was a warning that CodeQL did not run for a long time. That was due to renaming of the main branch to v2 and introducing a v3 branch.

## Contributor's checklist
- [x] Description states the purpose of the modifications
- [x] The PR contains only relevant modifications
- [x] Issues are linked (if applicable)
- [x] PHP-Code adheres to [PSR-12](https://www.php-fig.org/psr/psr-12/)
- [x] JS-Code adheres to [standardJS](https://standardjs.com/index.html)
- [x] Commits are atomic with a clear description
- [x] Changelog contains a user-centric summary
- [x] All modifications are tested (think of edge cases)
- [ ] GitHub actions succeed
