### PR TITLE
Pin psalm and the coding standard instead of tracking dev-master

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -14,8 +14,8 @@
   },
   "require-dev": {
     "nextcloud/ocp": "^v30",
-    "nextcloud/coding-standard": "dev-master",
-    "psalm/phar": "dev-master"
+    "nextcloud/coding-standard": "^1.5",
+    "psalm/phar": "^6.16"
   },
   "require": {
     "php": ">=8.1 <8.6"

--- a/composer.lock
+++ b/composer.lock
@@ -4,7 +4,7 @@
         "Read more about it at https://getcomposer.org/doc/01-basic-usage.md#installing-dependencies",
         "This file is @generated automatically"
     ],
-    "content-hash": "669c2fd90fb9be010d844707f9710528",
+    "content-hash": "acc7180683a1685be2ca3f0691e85c8d",
     "packages": [],
     "packages-dev": [
         {
@@ -61,7 +61,7 @@
         },
         {
             "name": "nextcloud/coding-standard",
-            "version": "dev-master",
+            "version": "v1.5.0",
             "source": {
                 "type": "git",
                 "url": "https://github.com/nextcloud/coding-standard.git",
@@ -78,7 +78,6 @@
                 "php": "^8.0",
                 "php-cs-fixer/shim": "^3.17"
             },
-            "default-branch": true,
             "type": "library",
             "autoload": {
                 "psr-4": {
@@ -101,7 +100,7 @@
             ],
             "support": {
                 "issues": "https://github.com/nextcloud/coding-standard/issues",
-                "source": "https://github.com/nextcloud/coding-standard/tree/master"
+                "source": "https://github.com/nextcloud/coding-standard/tree/v1.5.0"
             },
             "time": "2026-05-19T18:30:09+00:00"
         },
@@ -203,16 +202,16 @@
         },
         {
             "name": "psalm/phar",
-            "version": "dev-master",
+            "version": "6.16.1",
             "source": {
                 "type": "git",
                 "url": "https://github.com/psalm/phar.git",
-                "reference": "c4c1c6309bb043830492193cc224b392503b6cbc"
+                "reference": "11c6b55449667837fc07bb2a456c45a137c05ecd"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/psalm/phar/zipball/c4c1c6309bb043830492193cc224b392503b6cbc",
-                "reference": "c4c1c6309bb043830492193cc224b392503b6cbc",
+                "url": "https://api.github.com/repos/psalm/phar/zipball/11c6b55449667837fc07bb2a456c45a137c05ecd",
+                "reference": "11c6b55449667837fc07bb2a456c45a137c05ecd",
                 "shasum": ""
             },
             "require": {
@@ -221,7 +220,6 @@
             "conflict": {
                 "vimeo/psalm": "*"
             },
-            "default-branch": true,
             "bin": [
                 "psalm.phar"
             ],
@@ -233,9 +231,9 @@
             "description": "Composer-based Psalm Phar",
             "support": {
                 "issues": "https://github.com/psalm/phar/issues",
-                "source": "https://github.com/psalm/phar/tree/master"
+                "source": "https://github.com/psalm/phar/tree/6.16.1"
             },
-            "time": "2026-05-05T09:51:42+00:00"
+            "time": "2026-03-19T11:11:23+00:00"
         },
         {
             "name": "psr/clock",
@@ -441,10 +439,7 @@
     ],
     "aliases": [],
     "minimum-stability": "stable",
-    "stability-flags": {
-        "nextcloud/coding-standard": 20,
-        "psalm/phar": 20
-    },
+    "stability-flags": {},
     "prefer-stable": false,
     "prefer-lowest": false,
     "platform": {

--- a/psalm.xml
+++ b/psalm.xml
@@ -13,7 +13,6 @@
         <directory name="vendor" />
     </extraFiles>
     <issueHandlers>
-        <MissingPureAnnotation errorLevel="suppress" />
         <MissingOverrideAttribute errorLevel="suppress" />
     </issueHandlers>
 </psalm>


### PR DESCRIPTION
The static analysis has been failing on every push and pull request without any change on our side, because two dev dependencies tracked moving targets:

```json
"nextcloud/coding-standard": "dev-master",
"psalm/phar": "dev-master"
```

The current psalm master crashes on PHP 8.2+:

```
Uncaught RuntimeException: PHP Error: Creation of dynamic property
Psalm\Internal\Analyzer\StatementsAnalyzer::…
(Psalm dev-master@290eaec2 crashed due to an uncaught Throwable)
```

Identical code passed on 2026-06-20 and fails today — so this is upstream drift, not a regression in the app.

**Changes**
- Pin `psalm/phar` to `^6.16` and `nextcloud/coding-standard` to `^1.5`. Psalm 6 needs PHP ≥ 8.2, which the whole analysis matrix satisfies (8.2/8.3/8.4/8.5); the 8.1 job only lints and does not run psalm.
- Drop the `MissingPureAnnotation` suppression from `psalm.xml`. That issue type exists only on psalm's master (the upcoming 7.x), so a released 6.x refuses to parse the config. `MissingOverrideAttribute` stays — 6.16 does know it.

**Verified locally:** psalm reports no errors on PHP 8.2, 8.3, 8.4 and 8.5, and php-cs-fixer is clean with coding-standard 1.5.0.

This also unblocks the static analysis on #445.

🤖 Generated with [Claude Code](https://claude.com/claude-code), verified, tweaked and approved by @nursoda.
