### PR TITLE
Release 2.8.11

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,16 @@ This is the legacy version of the twofactor_email app for Nextcloud.
 The new version lacks translation, please help to integrate it, see
 https://github.com/datenschutz-individuell/twofactor_email/issues/6
 
+## 2.8.11 (2026-07-26)
+
+### Security
+
+- Update dependencies to fix advisories in the build toolchain
+
+### Changed
+
+- Modernized the build setup (ESLint 10 flat config, no Babel)
+
 ## 2.8.10 (2026-06-20)
 
 ### Changed

--- a/appinfo/info.xml
+++ b/appinfo/info.xml
@@ -1,7 +1,7 @@
 <?xml version="1.0"?>
 <info xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:noNamespaceSchemaLocation="https://apps.nextcloud.com/schema/apps/info.xsd">
 	<id>twofactor_email</id>
-	<version>2.8.10</version>
+	<version>2.8.11</version>
 	<dependencies>
 		<nextcloud min-version="30" max-version="33" />
 		<php min-version="8.1" max-version="8.5" />


### PR DESCRIPTION
Bumps the version to 2.8.11 and adds the changelog entry.

**What it ships**
- `axios` 1.18.1 in the bundle (was 1.17.0) — the only runtime change
- build-toolchain advisories closed: postcss (via an override that removes the nested postcss 7 vue-loader 15 drags in), fast-uri, fast-xml-parser, brace-expansion
- the ESLint 10 flat-config migration with Babel removed, and psalm/coding-standard pinned to releases instead of `dev-master`

Nothing user-visible changed. Dependabot alerts for this repo are down to **0**, except the two Vue 2 advisories that have no fix outside a Vue 3 migration.

Note: only `appinfo/info.xml` carries a version here — `package.json` and `package-lock.json` have no version field.

**Verified locally:** eslint, webpack build, psalm and php-cs-fixer all pass.

🤖 Generated with [Claude Code](https://claude.com/claude-code), verified, tweaked and approved by @nursoda.
