### PR TITLE
Add taint analysis, enforced by CI

### DIFF
--- a/.github/workflows/static-analysis.yml
+++ b/.github/workflows/static-analysis.yml
@@ -37,3 +37,11 @@ jobs:
         run: composer require --dev nextcloud/ocp:${{ matrix.ocp }}
       - name: Run coding standards check
         run: composer run -- psalm --php-version=${{ matrix.php }}
+
+      # Data-flow analysis, and it has to stay empty. Without this step the script
+      # exists but nothing enforces it, and PHP has no other SAST coverage here —
+      # codeql-analysis.yml is limited to javascript.
+      # It runs once per matrix cell rather than in a job of its own, which costs a
+      # couple of seconds per cell and saves duplicating the whole setup.
+      - name: Run taint analysis
+        run: composer run -- psalm:taint --php-version=${{ matrix.php }}

--- a/composer.json
+++ b/composer.json
@@ -10,7 +10,8 @@
     "lint": "find . -name \\*.php -not -path './vendor/*' -print0 | xargs -0 -n1 php -l",
     "cs:check": "php-cs-fixer fix --dry-run --diff",
     "cs:fix": "php-cs-fixer fix",
-    "psalm": "psalm.phar"
+    "psalm": "psalm.phar",
+    "psalm:taint": "psalm.phar --taint-analysis --ignore-baseline"
   },
   "require-dev": {
     "nextcloud/ocp": "^v30",

--- a/psalm.xml
+++ b/psalm.xml
@@ -6,7 +6,26 @@
     xsi:schemaLocation="https://getpsalm.org/schema/config vendor/vimeo/psalm/config.xsd"
     errorBaseline="tests/psalm-baseline.xml"
 >
+    <!--
+        The baseline serves the NORMAL run. That is why "composer psalm:taint" passes the
+        ignore-baseline flag: taint mode does not report the issues recorded here, so
+        every entry looks unused and the run fails with UnusedBaselineEntry instead of
+        with a finding about data flow.
+
+        Do NOT replace the baseline by suppressing MissingDependency below. That changes
+        the analysis, not just the reporting: psalm stops analysing calls on a class
+        whose parent it reports as missing, and resumes once the report is suppressed.
+        OCP\Template extends the private \OC_Template, which the OCP package does not
+        ship, so suppressing it produces "no constructor" and "no assign" for every
+        "new Template(...)" — errors with no apparent cause.
+
+        Note for whoever edits this: an XML comment must not contain two hyphens in a
+        row, so the flag above cannot be written with its dashes. Doing that turns the
+        whole file into "Missing psalm node".
+    -->
     <projectFiles>
+        <!-- lib only, so templates/ is not covered. The three templates here are almost
+             empty; if HTML sinks move into them, add the directory. -->
         <directory name="lib" />
     </projectFiles>
     <extraFiles>


### PR DESCRIPTION
The 3.x line runs psalm's taint analysis and keeps it empty; this line had no such script at all. For a branch that still serves Nextcloud 30 to 33 and carries a Vue 2 build chain, a data-flow check is worth more here than there, not less. It reports nothing today, which is the point: the result is a baseline to defend, not a to-do list.

**The review changed the shape of this.** The first version added only the composer script — and a script nobody runs is not a guarantee. Nothing in CI called it, and PHP has no other SAST coverage here: the CodeQL workflow is limited to `javascript`. That was demonstrated rather than argued: a class doing `echo $this->request->getParam('x')` is reported as `TaintedTextWithQuotes` and exits 2, yet CI would have stayed green and the XSS would have merged. The analysis now runs as a step in the existing matrix job — once per cell costs a couple of seconds and saves duplicating the whole setup.

**The `ignore-baseline` flag is load-bearing, and now says so in `psalm.xml`**, where the next reader looks. `tests/psalm-baseline.xml` serves the normal run; taint mode does not report those issues, so every entry looks unused and the run fails with ten `UnusedBaselineEntry` errors instead of with a finding about data flow. The comment also warns against the tempting cleanup: suppressing `MissingDependency` instead changes the *analysis* rather than the reporting — psalm stops analysing calls on a class whose parent it reports as missing and resumes once the report is suppressed, which produces "no constructor" and "no assign" for every `new Template(...)`, because `OCP\\Template` extends the private `\\OC_Template` that the OCP package does not ship.

Also recorded there: `templates/` is outside `projectFiles`, so the gate does not cover HTML sinks in them. The three templates here are almost empty and the 3.x line has the same scope, but it bounds what this check can be relied on for.

Verified with the exact CI invocation, cache cleared first: `composer run -- psalm:taint --php-version=8.5` reports no errors on PHP 8.5.9 with Psalm 6.16.1.

🤖 Generated with [Claude Code](https://claude.com/claude-code), verified, tweaked and approved by @nursoda.