### PR TITLE
Close the fast-uri and brace-expansion advisories

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1258,9 +1258,9 @@
       "license": "ISC"
     },
     "node_modules/brace-expansion": {
-      "version": "5.0.8",
-      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-5.0.8.tgz",
-      "integrity": "sha512-JZyDyq3D4AUifKTPOB7DELf6XsB3WdPuNxCtob1vFXPsSXhdAiHBWJ/tJ8HAc9aH84BK+5JFZLNkJKx3G9kzQg==",
+      "version": "5.0.9",
+      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-5.0.9.tgz",
+      "integrity": "sha512-ScQ4IuvIEF1TMlP7Zt+vjJ//9zlPb2SDcxWxM3bk8s6t6GGdJ7KO1dCcTidOPJKePW30LE/2cT7wCyPho9/Wxg==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
@@ -2038,9 +2038,9 @@
       "license": "MIT"
     },
     "node_modules/fast-uri": {
-      "version": "3.1.4",
-      "resolved": "https://registry.npmjs.org/fast-uri/-/fast-uri-3.1.4.tgz",
-      "integrity": "sha512-8JnbkQ4juDyvYs4mgFGQqg4yCYtFDtUtmp2QIQq11ZZe5CFQ5wcqm1rqDgAh/QdMySuBnPzMUiJUNZG5N/AiQw==",
+      "version": "3.1.5",
+      "resolved": "https://registry.npmjs.org/fast-uri/-/fast-uri-3.1.5.tgz",
+      "integrity": "sha512-gHwA1O9LDIcKunMKhObS/HimwtehO1nPUECKAu5TpKgaO19fcWEl4bliWe1jWxVFvIXztJjjQ4L8XQ1EU9f7Jw==",
       "dev": true,
       "funding": [
         {


### PR DESCRIPTION
Two in-range updates, lockfile only:

| Package | | Advisory |
|---|---|---|
| `fast-uri` | 3.1.4 → 3.1.5 | GHSA-7p8r-x3mc-p8w7 (host confusion, high) |
| `brace-expansion` | 5.0.8 → 5.0.9 | GHSA-rgw5-rvv9-x895 (unbounded intermediate arrays, high) |

**Dependabot found only the first one** (#463). The second was sitting in the vulnerable range `>=4.0.0 <5.0.9` with no alert at all. It surfaced by comparing this line against the others rather than by waiting to be told: the 3.x line closed both advisories a few hours earlier, in `main` and on `release/3.3`. That cross-check is now a standing habit.

`postcss` needs nothing here — 8.5.23 is exactly the first patched version for GHSA-fxqj-rqcc-2cmp, so v2 legitimately takes two of the three bumps v3 made.

What remains is the two Vue 2 findings this line carries deliberately: `vue` (low) and `vue-template-compiler` (moderate), neither with a fix short of Vue 3.

Verified: the resolved tree is at 3.1.5 and 5.0.9, `npm install --package-lock-only` reproduces the lockfile unchanged so `npm ci` will not drift, lint passes and the built `js/2fa-email.js` is byte-identical — both packages are dev-only and never reach the bundle. Severity is high, but the reach here is `eslint`→`minimatch` and `ajv`, not the shipped app.

Supersedes #463.

🤖 Generated with [Claude Code](https://claude.com/claude-code), verified, tweaked and approved by @nursoda.