### PR TITLE
Raise the fast-uri floor to the fully patched 3.1.7

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -7,20 +7,20 @@
       "name": "twofactor_email",
       "license": "AGPL-3.0-or-later",
       "dependencies": {
-        "@nextcloud/axios": "*",
-        "@nextcloud/initial-state": "*",
-        "nextcloud-server": "*",
+        "@nextcloud/axios": "latest",
+        "@nextcloud/initial-state": "latest",
+        "nextcloud-server": "latest",
         "vue": "v2-latest"
       },
       "devDependencies": {
         "@nextcloud/eslint-config": "^9.0.1",
-        "css-loader": "*",
-        "eslint": "*",
-        "vue-loader": "*",
-        "vue-template-compiler": "*",
-        "webpack": "*",
-        "webpack-cli": "*",
-        "webpack-merge": "*"
+        "css-loader": "latest",
+        "eslint": "latest",
+        "vue-loader": "legacy",
+        "vue-template-compiler": "latest",
+        "webpack": "latest",
+        "webpack-cli": "latest",
+        "webpack-merge": "latest"
       },
       "engines": {
         "node": ">=24",

--- a/package.json
+++ b/package.json
@@ -46,6 +46,7 @@
     "webpack-merge": "latest"
   },
   "overrides": {
+    "fast-uri": "^3.1.7",
     "postcss": "^8.5.23"
   }
 }


### PR DESCRIPTION
Follow-up to #468, which closed alerts 110–113 by lifting `fast-uri` to 3.1.7.

`fast-uri` only ever arrives transitively (webpack → schema-utils → ajv, which asks for `^3.0.1`), so nothing keeps it at 3.1.7 — the next lock file refresh may resolve back into the vulnerable range and reopen the alerts. An `overrides` entry pins the floor, alongside the `postcss` one that is already there.

3.1.7 rather than 3.1.6, because 3.1.6 does not yet carry GHSA-qw65-cvwx-89v3 (authority injection via an unvalidated port) and GHSA-58mr-gqgx-xq4g (host confusion via misplaced IP-literal brackets).

Resolved version does not change, so the build is unaffected. The lock file carries one unrelated hunk: the install rewrote the root block's dist-tag specifiers, which an older npm had flattened to `*`, back to the `latest`/`legacy` that `package.json` declares.

The same floor went into the v3 tree, where `fast-uri` had been sitting at 3.1.6.

🤖 Generated with [Claude Code](https://claude.com/claude-code)