### PR TITLE
Drop the fast-uri override, which no longer changes anything

### DIFF
--- a/package.json
+++ b/package.json
@@ -46,7 +46,6 @@
     "webpack-merge": "latest"
   },
   "overrides": {
-    "fast-uri": "^3.1.7",
     "postcss": "^8.5.23"
   }
 }


### PR DESCRIPTION
## What this does

Removes the `fast-uri` override from `package.json`. It no longer changes anything.

The only requester is `ajv`, through `schema-utils` and `ajv-formats`, and it asks for
`^3.0.1`. Since 3.1.7 is the newest release of the 3.x line, npm resolves the same
version with or without the override — and the lock file proves it: removing the entry
leaves `package-lock.json` byte for byte unchanged.

## Why remove it rather than leave it

It was added as a floor against an advisory that 3.1.7 closes. A floor that the natural
resolution already meets is not a guard, it is debt: the next reader has to work out
what it protects against before touching anything near it. Should a 3.1.8 appear, npm
picks it up on its own.

## The postcss override stays

`@vue/component-compiler-utils` asks for `^7.0.36`, so only the override keeps the whole
tree on 8.x. That one still earns its place.

The remaining two audit findings, both in the Vue 2 line, stay untouched.

The same entry is removed from the 3.x line in a pull request of its own.

## Testing

`npm ci` resolves `fast-uri@3.1.7` as before; `npm run lint` and `npm run build` are
green.

🤖 Generated with [Claude Code](https://claude.com/claude-code), verified, tweaked and approved by @nursoda.
