### PR TITLE
Pin dependencies to semver ranges instead of dist-tags

### DIFF
--- a/README.md
+++ b/README.md
@@ -5,6 +5,8 @@ In 2024, this app wasn't updated for a while and left admins and their users in 
 I will make sure v2 is secure¹ and works for officially supported versions up to 31 as long as they are officially supported. For smooth transition, I released version 2.8.x that still work with the old code even on Nextcloud 33. But it uses quite a lot of deprecated APIs (and old dependencies) si it is strongly recommended to switch to v3. All existing v2 functionality is there, and quite some translations are already integrated. Some users and myself are using it for more than a year now, so we released it non-beta in May, 2026.
 ___
 *¹Security: I am aware that this app has npm security warnings when building it. This in not due to my code but due to Nextcloud dependencies still relying on vue2, which is EOL since end of 2023 (and that EOL was annonced more than a year before that). When resolving dependencies, packages are used that do have known issues. Most of them are development dependencies "only" (meaning that potentially vulnerable code is not in the build code, but only used when building it) - with one notable exception: vue2.*
+
+*Version ceiling: `vue` and `vue-template-compiler` stay at 2.7.16 (the last Vue 2 release), `vue-loader` at 15.x (16+ requires Vue 3). The `^` ranges in `package.json` enforce this - do not widen them.*
 ___
 
 # Two-Factor Email Provider for Nextcloud

--- a/package-lock.json
+++ b/package-lock.json
@@ -7,20 +7,20 @@
       "name": "twofactor_email",
       "license": "AGPL-3.0-or-later",
       "dependencies": {
-        "@nextcloud/axios": "*",
-        "@nextcloud/initial-state": "*",
-        "nextcloud-server": "*",
-        "vue": "v2-latest"
+        "@nextcloud/axios": "^2.6.0",
+        "@nextcloud/initial-state": "^3.0.0",
+        "nextcloud-server": "^0.15.10",
+        "vue": "^2.7.16"
       },
       "devDependencies": {
         "@nextcloud/eslint-config": "^9.0.1",
-        "css-loader": "*",
-        "eslint": "*",
-        "vue-loader": "*",
-        "vue-template-compiler": "*",
-        "webpack": "*",
-        "webpack-cli": "latest",
-        "webpack-merge": "*"
+        "css-loader": "^7.1.5",
+        "eslint": "^10.8.1",
+        "vue-loader": "^15.11.1",
+        "vue-template-compiler": "^2.7.16",
+        "webpack": "^5.109.2",
+        "webpack-cli": "^7.2.3",
+        "webpack-merge": "^6.0.1"
       },
       "engines": {
         "node": ">=24",

--- a/package.json
+++ b/package.json
@@ -30,20 +30,20 @@
     "lint:fix": "eslint src --fix"
   },
   "dependencies": {
-    "@nextcloud/axios": "latest",
-    "@nextcloud/initial-state": "latest",
-    "nextcloud-server": "latest",
-    "vue": "v2-latest"
+    "@nextcloud/axios": "^2.6.0",
+    "@nextcloud/initial-state": "^3.0.0",
+    "nextcloud-server": "^0.15.10",
+    "vue": "^2.7.16"
   },
   "devDependencies": {
     "@nextcloud/eslint-config": "^9.0.1",
-    "css-loader": "latest",
-    "eslint": "latest",
-    "vue-loader": "legacy",
-    "vue-template-compiler": "latest",
-    "webpack": "latest",
-    "webpack-cli": "latest",
-    "webpack-merge": "latest"
+    "css-loader": "^7.1.5",
+    "eslint": "^10.8.1",
+    "vue-loader": "^15.11.1",
+    "vue-template-compiler": "^2.7.16",
+    "webpack": "^5.109.2",
+    "webpack-cli": "^7.2.3",
+    "webpack-merge": "^6.0.1"
   },
   "overrides": {
     "postcss": "^8.5.23"


### PR DESCRIPTION
Dependabot's npm flattens dist-tag specs (`latest`, `legacy`, `v2-latest`) to `*` in
`package-lock.json`, which drifts from `package.json` on every dependency PR. More
importantly, `*` would have allowed vue-loader 17 (Vue 3) into a branch that must stay
on Vue 2.

Replaces all eleven dist-tag specs with semver ranges that pin the currently resolved
versions, so no installed version changes:

- `vue`, `vue-template-compiler` -> `^2.7.16` (last Vue 2 release)
- `vue-loader` -> `^15.11.1` (16+ requires Vue 3)
- the rest -> caret ranges on their current versions

`package-lock.json` carries the same specs, so the drift cannot come back.
`npm ci --dry-run` confirms both files are in sync.

The README's existing Vue 2 section now names the ceiling explicitly.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
